### PR TITLE
✨ Webtoon Screen과 관련된 스크롤 애니메이션 구현

### DIFF
--- a/src/components/Header/WebtoonHeader.tsx
+++ b/src/components/Header/WebtoonHeader.tsx
@@ -19,6 +19,8 @@ export default function Header() {
 
 const styles = StyleSheet.create({
   header: {
+    zIndex: 3,
+    position: 'absolute',
     width: '100%',
     height: HEIGHTS.HEADER,
     alignItems: 'center',

--- a/src/components/Header/WebtoonHeader.tsx
+++ b/src/components/Header/WebtoonHeader.tsx
@@ -5,12 +5,18 @@ import Search from '@/components/Icon/Search';
 
 import { HEIGHTS, scale } from '@/styles/dimensions';
 
-export default function Header() {
+export default function Header({ scrollY }: { scrollY: Animated.Value }) {
+  const headerTranslateY = scrollY.interpolate({
+    inputRange: [0, HEIGHTS.HEADER / 10],
+    outputRange: [-HEIGHTS.HEADER, 0],
+    extrapolate: 'clamp',
+  });
+
   return (
     <>
       <Cookie onPressHandler={() => alert('press cookie')} style={{ ...styles.headerIcon, ...styles.headerLeft }} />
       <Search onPressHandler={() => alert('press search')} style={{ ...styles.headerIcon, ...styles.headerRight }} />
-      <Animated.View style={styles.header}>
+      <Animated.View style={[styles.header, { transform: [{ translateY: headerTranslateY }] }]}>
         <Text>인기순</Text>
       </Animated.View>
     </>

--- a/src/components/WebtoonList/index.tsx
+++ b/src/components/WebtoonList/index.tsx
@@ -1,4 +1,4 @@
-import { Animated, Pressable, StyleSheet, Text } from 'react-native';
+import { Animated, LayoutRectangle, Pressable, StyleSheet, Text } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { HEIGHTS, scale } from '@/styles/dimensions';
 import { DetailScreenProps } from '@/navigations/types';
@@ -28,12 +28,21 @@ const DATA: DataTypes[] = [
 ];
 
 // 대략적인 구조
-export default function WebtoonList({ category }: { category: string }) {
+export default function WebtoonList({
+  category,
+  scrollY,
+  tabBarLayoutSize,
+}: {
+  category: string;
+  scrollY: Animated.Value;
+  tabBarLayoutSize: LayoutRectangle;
+}) {
   const navigation = useNavigation<DetailScreenProps['navigation']>();
 
   return (
     <Animated.FlatList
-      contentContainerStyle={styles.container}
+      contentContainerStyle={{ ...styles.container, ...{ paddingTop: tabBarLayoutSize.height + HEIGHTS.MAIN_BANNER } }}
+      onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], { useNativeDriver: true })}
       data={DATA}
       numColumns={3}
       renderItem={({ item }) => (

--- a/src/components/WebtoonList/index.tsx
+++ b/src/components/WebtoonList/index.tsx
@@ -1,0 +1,65 @@
+import { Animated, Pressable, StyleSheet, Text } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { HEIGHTS, scale } from '@/styles/dimensions';
+import { DetailScreenProps } from '@/navigations/types';
+
+interface DataTypes {
+  id: number;
+  title: string;
+}
+
+// 임시 데이터
+const DATA: DataTypes[] = [
+  { id: 0, title: 'no title' },
+  { id: 1, title: 'no title' },
+  { id: 2, title: 'no title' },
+  { id: 3, title: 'no title' },
+  { id: 4, title: 'no title' },
+  { id: 5, title: 'no title' },
+  { id: 6, title: 'no title' },
+  { id: 7, title: 'no title' },
+  { id: 8, title: 'no title' },
+  { id: 9, title: 'no title' },
+  { id: 10, title: 'no title' },
+  { id: 11, title: 'no title' },
+  { id: 12, title: 'no title' },
+  { id: 13, title: 'no title' },
+  { id: 14, title: 'no title' },
+];
+
+// 대략적인 구조
+export default function WebtoonList({ category }: { category: string }) {
+  const navigation = useNavigation<DetailScreenProps['navigation']>();
+
+  return (
+    <Animated.FlatList
+      contentContainerStyle={styles.container}
+      data={DATA}
+      numColumns={3}
+      renderItem={({ item }) => (
+        <Pressable
+          style={styles.card}
+          onPress={() => navigation.navigate('DetailScreen', { id: item.id, title: item.title, from: 'WebtoonScreen' })}
+        >
+          <Text>
+            {category}: {item.title}-{item.id}
+          </Text>
+        </Pressable>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingBottom: HEIGHTS.BOTTOM_BANNER,
+    paddingHorizontal: scale(4),
+  },
+  card: {
+    flex: 1,
+    width: scale(150),
+    height: scale(150),
+    backgroundColor: '#fff',
+    margin: scale(4),
+  },
+});

--- a/src/hooks/useLayout.tsx
+++ b/src/hooks/useLayout.tsx
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react';
+import { LayoutChangeEvent, LayoutRectangle } from 'react-native';
+
+const useOnLayout = () => {
+  const [layoutSize, setLayoutSize] = useState<LayoutRectangle>({
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+  });
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    const { width, height, x, y } = e.nativeEvent.layout;
+    setLayoutSize({ width, height, x, y });
+  }, []);
+
+  return [layoutSize, onLayout];
+};
+
+export default useOnLayout;

--- a/src/screens/Webtoon.tsx
+++ b/src/screens/Webtoon.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { View, StyleSheet, Animated, LayoutRectangle, LayoutChangeEvent, Text } from 'react-native';
 import { TabBar, TabView } from 'react-native-tab-view';
 
@@ -54,6 +54,10 @@ export default function HomeScreen() {
     outputRange: [HEIGHTS.BOTTOM_BANNER, 0],
     extrapolate: 'clamp',
   });
+
+  useEffect(() => {
+    scrollY.setValue(0);
+  }, [index]);
 
   return (
     <View style={styles.container}>

--- a/src/screens/Webtoon.tsx
+++ b/src/screens/Webtoon.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { useRef, useState } from 'react';
-import { View, StyleSheet, Animated, LayoutRectangle, LayoutChangeEvent } from 'react-native';
+import { View, StyleSheet, Animated, LayoutRectangle, LayoutChangeEvent, Text } from 'react-native';
 import { TabBar, TabView } from 'react-native-tab-view';
 
 import Header from '@/components/Header/WebtoonHeader';
 import MainBanner from '@/components/Banner/MainBanner';
+import WebtoonList from '@/components/WebtoonList';
 
 import { HEIGHTS, WIDTHS } from '@/styles/dimensions';
 
@@ -48,9 +49,15 @@ export default function HomeScreen() {
     extrapolate: 'clamp',
   });
 
+  const footerTranslateY = scrollY.interpolate({
+    inputRange: [0, HEIGHTS.BOTTOM_BANNER / 10],
+    outputRange: [HEIGHTS.BOTTOM_BANNER, 0],
+    extrapolate: 'clamp',
+  });
+
   return (
     <View style={styles.container}>
-      <Header />
+      <Header scrollY={scrollY} />
 
       <Animated.View style={[styles.mainBannerContainer, { transform: [{ translateY: bannerTranslateY }] }]}>
         <MainBanner />
@@ -80,6 +87,10 @@ export default function HomeScreen() {
         onIndexChange={setIndex}
         initialLayout={{ width: WIDTHS.WINDOW }}
       />
+
+      <Animated.View style={[styles.bottomBanner, { transform: [{ translateY: footerTranslateY }] }]}>
+        <Text>Bottom banner</Text>
+      </Animated.View>
     </View>
   );
 }
@@ -116,5 +127,16 @@ const styles = StyleSheet.create({
     color: 'black',
     margin: 0,
     fontSize: 10,
+  },
+  bottomBanner: {
+    zIndex: 2,
+    bottom: 0,
+    position: 'absolute',
+    width: '100%',
+    height: HEIGHTS.BOTTOM_BANNER,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: 'skyblue',
   },
 });

--- a/src/screens/Webtoon.tsx
+++ b/src/screens/Webtoon.tsx
@@ -7,7 +7,7 @@ import Header from '@/components/Header/WebtoonHeader';
 import MainBanner from '@/components/Banner/MainBanner';
 
 import { scale, WIDTHS } from '@/styles/dimensions';
-import { useNavigation } from '@react-navigation/native';
+import WebtoonList from '@/components/WebtoonList';
 import { DetailScreenProps } from '@/navigations/types';
 
 interface RouteType {
@@ -52,14 +52,7 @@ export default function HomeScreen() {
           />
         )}
         navigationState={{ index, routes }}
-        renderScene={(props) => (
-          <Pressable
-            style={styles.item}
-            onPress={() => navigation.navigate('DetailScreen', { id: 1, title: '웹툰1', from: 'WebtoonScreen' })}
-          >
-            <Text>{props.route.title} 웹툰</Text>
-          </Pressable>
-        )} // 추후 다른 컴포넌트로 교체
+        renderScene={(props) => <WebtoonList category={props.route.key} />}
         onIndexChange={setIndex}
         initialLayout={{ width: WIDTHS.WINDOW }}
       />


### PR DESCRIPTION
## 관련 이슈
- #4 

## 구현 내용
[✏️ 노션에서 자세히 보기](https://cypress-pink-680.notion.site/2-Animated-ae627d176e9f439d9d612406218e3528)

1. 스크롤 시 메인 배너가 완전히 가려지면 요일 탭이 헤더에 고정되도록 구현
2. 스크롤 시 메인 배너와 하단 배너가 나타나도록 구현


https://user-images.githubusercontent.com/85747667/224482889-e7e317f4-db7f-4a9d-ac8b-6624842ccf7b.mp4



## 해결하지 못한 것
요일 탭을 이동해도 스크롤 위치가 동기화 되도록 하기

https://user-images.githubusercontent.com/85747667/224482831-7a1ee098-809f-4c19-9d1e-2c05cf6cf2e8.mp4



임시로 탭이동을 하면 스크롤이 초기화 되도록 처리했다 🥺 UI 구현이 다 끝난 후에 다시 도전하기로

https://user-images.githubusercontent.com/85747667/224482996-bf9d711d-47f0-454e-a0fd-850284891f10.mp4


