### PR TITLE
✨ MyScreen과 DetailScreen의 컨텐츠 배치 및 UI 기능 구현

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -5,7 +5,7 @@ import CardImage from '@/components/Card/CardImage';
 
 import { CARD_SIZE, scale } from '@/styles/dimensions';
 
-export default function Card({ cardData, cardStyle, ranking }: CardProps) {
+export default function Card({ cardData, cardStyle, ranking, episode }: CardProps) {
   const { imageSize, direction } = cardStyle;
   const { title, imageDownloadUrl, pictrWritrNm, sntncWritrNm } = cardData;
 
@@ -27,10 +27,14 @@ export default function Card({ cardData, cardStyle, ranking }: CardProps) {
         )}
 
         <View style={ranking ? rankingTitleContainerStyles : styles.titleContainer}>
-          <Text style={styles.title} numberOfLines={1}>
-            {title}
-          </Text>
-          {(imageSize === 'tiny' && direction !== 'horizontal') || (
+          <View style={{ flexDirection: 'row' }}>
+            {episode && <Text style={styles.title}>{episode}화. </Text>}
+            <Text style={styles.title} numberOfLines={1}>
+              {title}
+            </Text>
+          </View>
+
+          {(imageSize === 'tiny' && direction !== 'horizontal') || !!episode || (
             <Text style={styles.writer} numberOfLines={1}>
               {pictrWritrNm}, {sntncWritrNm}
             </Text>

--- a/src/components/Header/DetailHeader.tsx
+++ b/src/components/Header/DetailHeader.tsx
@@ -1,18 +1,25 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
+import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { Ionicons, EvilIcons, MaterialCommunityIcons } from '@expo/vector-icons';
-
 import { DetailScreenProps, MyScreenProps } from '@/types/navigation';
+
+import { Ionicons, MaterialCommunityIcons, AntDesign } from '@expo/vector-icons';
 import { HEIGHTS, scale } from '@/styles/dimensions';
+
+interface SubscribeState {
+  id: number;
+  subscribe: boolean;
+  notification: boolean;
+}
 
 export default function DetailHeader() {
   const detailNavigation = useNavigation<DetailScreenProps['navigation']>();
   const myScreenNavigation = useNavigation<MyScreenProps['navigation']>();
   const {
-    params: { from, title },
+    params: { from, title, id: paramsId },
   } = useRoute<DetailScreenProps['route']>();
 
-  const onPressHandler = () => {
+  const backBtnPressHandler = () => {
     const moveMyScreen = () => {
       detailNavigation.pop();
       myScreenNavigation.navigate('MyScreen');
@@ -21,21 +28,81 @@ export default function DetailHeader() {
     return from === 'MyScreen' ? moveMyScreen() : detailNavigation.pop();
   };
 
+  const [subscribeState, setSubscribeState] = useState<SubscribeState | null>(null);
+  const [checkSubscribeButton, setCheckSubscribeButton] = useState<boolean>(false);
+  const [notificationActive, setNotificationActive] = useState<boolean>(false);
+
+  const showNotificationSettings = (id: number) =>
+    Alert.alert('', '관심 웹툰 알림설정이 꺼져있어요.\n알림을 켜고 업데이트 소식을 받으시겠어요?', [
+      {
+        text: 'Cancel',
+        onPress: () => setSubscribeState({ id, subscribe: true, notification: false }),
+        style: 'cancel',
+      },
+      { text: 'OK', onPress: () => setSubscribeState({ id, subscribe: true, notification: true }) },
+    ]);
+
+  const SubscribeBtnPressHandler = (id: number) => {
+    if (!subscribeState) {
+      setNotificationActive(true);
+      setCheckSubscribeButton(true);
+      return showNotificationSettings(id);
+    }
+
+    if (subscribeState.subscribe) {
+      setNotificationActive(false);
+      setCheckSubscribeButton(false);
+      return setSubscribeState({ ...subscribeState, subscribe: !subscribeState.subscribe, notification: false });
+    }
+
+    setNotificationActive(true);
+    return setSubscribeState({ ...subscribeState, subscribe: !subscribeState.subscribe, notification: true });
+  };
+
+  const notificationBtnPressHandler = () => {
+    if (!subscribeState) return;
+    // eslint-disable-next-line consistent-return
+    return setSubscribeState({ ...subscribeState, notification: !subscribeState.notification });
+  };
+
+  const isSubscribe = subscribeState?.subscribe;
+
+  const subscribeButtonName = () => {
+    if (isSubscribe) {
+      return 'checkcircle';
+    }
+    if (checkSubscribeButton) {
+      return 'pluscircle';
+    }
+    return 'pluscircleo';
+  };
+
   return (
     <View style={styles.header}>
       <View style={{ ...styles.headerContent, ...styles.contentGap }}>
-        <Pressable onPress={onPressHandler}>
+        <Pressable onPress={backBtnPressHandler}>
           <Ionicons name="chevron-back" size={24} color="black" />
         </Pressable>
         <Text style={styles.contentTitle}>{title}</Text>
       </View>
       <View style={styles.headerContent}>
-        <Pressable style={{ ...styles.headerContent, ...styles.subscribe }}>
-          <EvilIcons name="plus" size={24} color="black" />
+        <Pressable
+          style={{ ...styles.headerContent, ...styles.subscribe, ...styles.contentGap }}
+          onPress={() => SubscribeBtnPressHandler(paramsId)}
+        >
+          <AntDesign
+            name={subscribeButtonName() as 'pluscircle' | 'checkcircle' | 'pluscircleo'}
+            size={20}
+            color={isSubscribe || checkSubscribeButton ? 'green' : 'black'}
+          />
           <Text>관심</Text>
         </Pressable>
-        <Pressable>
-          <MaterialCommunityIcons name="bell-off-outline" size={24} color="black" />
+        <Pressable onPress={notificationBtnPressHandler} style={!notificationActive && styles.hide}>
+          <MaterialCommunityIcons
+            name={subscribeState?.notification ? 'bell' : 'bell-off-outline'}
+            size={24}
+            color={subscribeState?.notification ? 'orange' : 'black'}
+          />
         </Pressable>
       </View>
     </View>
@@ -60,12 +127,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   contentGap: {
-    gap: scale(8),
+    gap: scale(4),
   },
   contentTitle: {
     fontSize: scale(16),
   },
   subscribe: {
     paddingRight: scale(12),
+  },
+  hide: {
+    display: 'none',
   },
 });

--- a/src/components/Header/DetailHeader.tsx
+++ b/src/components/Header/DetailHeader.tsx
@@ -45,7 +45,6 @@ export default function DetailHeader() {
 const styles = StyleSheet.create({
   header: {
     zIndex: 1,
-    position: 'absolute',
     width: '100%',
     height: HEIGHTS.HEADER,
     backgroundColor: '#fff',
@@ -53,6 +52,8 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
     flexDirection: 'row',
     padding: scale(10),
+    borderBottomWidth: 1,
+    borderBottomColor: 'lightgray',
   },
   headerContent: {
     flexDirection: 'row',

--- a/src/navigations/MainNavigator.tsx
+++ b/src/navigations/MainNavigator.tsx
@@ -8,7 +8,7 @@ import WebtoonNavigator from '@/navigations/WebtoonNavigator';
 import MyScreen from '@/screens/My';
 
 import Search from '@/components/Icon/Search';
-import { scale } from '@/styles/dimensions';
+import { HEIGHTS, scale } from '@/styles/dimensions';
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
@@ -32,6 +32,7 @@ export default function MainTabNavigator() {
         component={MyScreen}
         options={{
           title: 'My',
+          headerStyle: { borderBottomWidth: 1, height: HEIGHTS.HEADER, borderBottomColor: 'lightgray' },
           headerTitleAlign: 'left',
           headerRight: () => <Search style={styles.search} onPressHandler={() => alert('press search')} />,
           tabBarActiveTintColor: 'green',

--- a/src/screens/My.tsx
+++ b/src/screens/My.tsx
@@ -1,14 +1,39 @@
+import { useState } from 'react';
 import { FlatList, Pressable, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { DetailScreenProps } from '@/types/navigation';
+import { ResponseItemData } from '@/types/api';
 
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import Card from '@/components/Card';
 import { scale } from '@/styles/dimensions';
 import { makeMockWebtoonList } from '@/utils/mockWebtoonList';
 
+interface NotificationState {
+  id: number;
+  notification: boolean;
+}
+
 export default function MyScreen() {
   const navigation = useNavigation<DetailScreenProps['navigation']>();
+  const [notificationState, setNotificationState] = useState<NotificationState[]>([]);
+
+  const findNotificationState = (id: string) => notificationState.findIndex((el) => el.id === Number(id));
+  const onPressHandler = (item: ResponseItemData) => {
+    const findIndex = findNotificationState(item.mastrId);
+    if (findIndex < 0) {
+      return setNotificationState([...notificationState, { id: Number(item.mastrId), notification: true }]);
+    }
+
+    const changeAlramState = [...notificationState].map((state) =>
+      state.id === Number(item.mastrId) ? { ...state, notification: !state.notification } : state,
+    );
+
+    return setNotificationState(changeAlramState);
+  };
+
+  const isAlramActive = (id: string) =>
+    notificationState[findNotificationState(id)] && notificationState[findNotificationState(id)].notification;
 
   return (
     <FlatList
@@ -23,8 +48,12 @@ export default function MyScreen() {
           >
             <Card cardData={item} cardStyle={{ imageSize: 'tiny', direction: 'horizontal' }} />
           </Pressable>
-          <Pressable style={{}} onPress={() => {}}>
-            <MaterialCommunityIcons name="bell" size={24} color="green" />
+          <Pressable style={{}} onPress={() => onPressHandler(item)}>
+            <MaterialCommunityIcons
+              name={isAlramActive(item.mastrId) ? 'bell' : 'bell-off-outline'}
+              size={24}
+              color={isAlramActive(item.mastrId) ? 'green' : 'black'}
+            />
           </Pressable>
         </View>
       )}

--- a/src/screens/My.tsx
+++ b/src/screens/My.tsx
@@ -1,25 +1,44 @@
-import { Button, StyleSheet, View } from 'react-native';
+import { FlatList, Pressable, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { DetailScreenProps } from '@/types/navigation';
+
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import Card from '@/components/Card';
+import { scale } from '@/styles/dimensions';
+import { makeMockWebtoonList } from '@/utils/mockWebtoonList';
 
 export default function MyScreen() {
   const navigation = useNavigation<DetailScreenProps['navigation']>();
 
   return (
-    <View style={styles.container}>
-      <Button
-        title="웹툰 상세 페이지로 가기"
-        onPress={() => navigation.navigate('DetailScreen', { id: 1, title: '웹툰1', from: 'MyScreen' })}
-      />
-    </View>
+    <FlatList
+      contentContainerStyle={styles.FlatListContainer}
+      data={makeMockWebtoonList(13)}
+      renderItem={({ item }) => (
+        <View style={styles.itemContainer}>
+          <Pressable
+            onPress={() =>
+              navigation.navigate('DetailScreen', { id: Number(item.mastrId), title: item.title, from: 'MyScreen' })
+            }
+          >
+            <Card cardData={item} cardStyle={{ imageSize: 'tiny', direction: 'horizontal' }} />
+          </Pressable>
+          <Pressable style={{}} onPress={() => {}}>
+            <MaterialCommunityIcons name="bell" size={24} color="green" />
+          </Pressable>
+        </View>
+      )}
+    />
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
+export const styles = StyleSheet.create({
+  FlatListContainer: { backgroundColor: '#fff' },
+  itemContainer: {
     flex: 1,
-    backgroundColor: '#ffcdd2',
+    flexDirection: 'row',
+    margin: scale(8),
+    justifyContent: 'space-between',
     alignItems: 'center',
-    justifyContent: 'center',
   },
 });

--- a/src/screens/WebtoonDetail.tsx
+++ b/src/screens/WebtoonDetail.tsx
@@ -1,18 +1,33 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { DetailScreenProps } from '@/types/navigation';
+import { FlatList, Pressable, StyleSheet, View } from 'react-native';
+
+import { Feather } from '@expo/vector-icons';
 import DetailHeader from '@/components/Header/DetailHeader';
+import Card from '@/components/Card';
+import { scale } from '@/styles/dimensions';
 
-export default function DetailScreen({ route }: DetailScreenProps) {
-  const { id, title } = route.params;
+import { makeMockWebtoonList } from '@/utils/mockWebtoonList';
 
+export default function DetailScreen() {
   return (
     <View style={styles.container}>
       <DetailHeader />
-      <View style={styles.item}>
-        <Text>
-          웹툰 상세 id: {id}, title: {title}
-        </Text>
-      </View>
+
+      <FlatList
+        contentContainerStyle={styles.FlatListContainer}
+        data={makeMockWebtoonList(20).reverse()}
+        renderItem={({ item, index }) => (
+          <View style={styles.itemContainer}>
+            <Card
+              cardData={item}
+              cardStyle={{ imageSize: 'tiny', direction: 'horizontal' }}
+              episode={makeMockWebtoonList(20).length - index}
+            />
+          </View>
+        )}
+      />
+      <Pressable style={styles.arrow} onPress={() => {}}>
+        <Feather name="arrow-up" size={32} color="black" />
+      </Pressable>
     </View>
   );
 }
@@ -22,10 +37,17 @@ const styles = StyleSheet.create({
     flex: 1,
     position: 'relative',
   },
-  item: {
+  FlatListContainer: { backgroundColor: '#fff' },
+  itemContainer: {
     flex: 1,
+    flexDirection: 'row',
+    margin: scale(8),
+    justifyContent: 'space-between',
     alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'skyblue',
+  },
+  arrow: {
+    position: 'absolute',
+    bottom: scale(40),
+    right: scale(20),
   },
 });

--- a/src/screens/WebtoonDetail.tsx
+++ b/src/screens/WebtoonDetail.tsx
@@ -1,18 +1,29 @@
-import { FlatList, Pressable, StyleSheet, View } from 'react-native';
+import { useRef } from 'react';
+import { Animated, FlatList, Pressable, StyleSheet, View } from 'react-native';
 
 import { Feather } from '@expo/vector-icons';
 import DetailHeader from '@/components/Header/DetailHeader';
 import Card from '@/components/Card';
-import { scale } from '@/styles/dimensions';
+import { HEIGHTS, scale } from '@/styles/dimensions';
 
 import { makeMockWebtoonList } from '@/utils/mockWebtoonList';
 
 export default function DetailScreen() {
+  const scrollY = useRef(new Animated.Value(0)).current;
+  const flatListRef = useRef<FlatList | null>(null);
+
+  const arrowButtonActive = scrollY.interpolate({
+    inputRange: [0, HEIGHTS.WINDOW / 6],
+    outputRange: [0, 0.5],
+  });
+
   return (
     <View style={styles.container}>
       <DetailHeader />
 
-      <FlatList
+      <Animated.FlatList
+        ref={flatListRef}
+        onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], { useNativeDriver: true })}
         contentContainerStyle={styles.FlatListContainer}
         data={makeMockWebtoonList(20).reverse()}
         renderItem={({ item, index }) => (
@@ -25,9 +36,11 @@ export default function DetailScreen() {
           </View>
         )}
       />
-      <Pressable style={styles.arrow} onPress={() => {}}>
-        <Feather name="arrow-up" size={32} color="black" />
-      </Pressable>
+      <Animated.View style={[styles.arrow, { opacity: arrowButtonActive }]}>
+        <Pressable onPress={() => flatListRef.current?.scrollToOffset({ animated: true, offset: 0 })}>
+          <Feather name="arrow-up" size={32} color="black" />
+        </Pressable>
+      </Animated.View>
     </View>
   );
 }

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -9,6 +9,7 @@ export interface CardProps {
   cardData: ResponseItemData;
   cardStyle: CardStyleProps;
   ranking?: number;
+  episode?: number;
 }
 
 type CardImageInfoProps = Pick<ResponseItemData, 'title' | 'imageDownloadUrl'>;


### PR DESCRIPTION
## 관련 이슈
- #8 

## 구현 내용
❗️모든 state는 전역 상태를 가지고 있지 않다❗️ 
- 스크린 이동을 하면 리셋된다.
- MyScreen의 상태와 DetailScreen 상태는 별개이다. 가능하다면 useContext으로 전역 상태를 공유하도록 수정 예정

### MyScreen
<img src="https://user-images.githubusercontent.com/85747667/224532436-6d4562ac-cdca-415d-8d90-cc141d36af05.gif" width="50%">


### DetailScreen
헤더의 버튼 애니메이션은 시간상 구현하지 못했다.

<img src="https://user-images.githubusercontent.com/85747667/224532065-9bff73e4-5663-43f6-b427-6782526c0e28.gif" width="50%">

- 스크롤을 내리면 우측 하단에 화살표 버튼이 활성화 되며, 클릭시 스크롤이 최상단으로 이동하게 된다.
- 관심 버튼을 클릭하면 1회에 한해서 알림 설정에 대한 Alert 알림창이 뜬다.
- 구독 버튼이 활성화 되면 노란 종모양으로 바뀐다.

